### PR TITLE
fix: handle picker placeholder value

### DIFF
--- a/frontend/src/screens/CompraScreen.tsx
+++ b/frontend/src/screens/CompraScreen.tsx
@@ -56,11 +56,11 @@ export default function CompraScreen(): React.JSX.Element {
         render={({ field: { onChange, value } }) => (
           <View className="border border-border rounded-2xl overflow-hidden bg-card">
             <Picker
-              selectedValue={value as TipoCompra | undefined}
-              onValueChange={(val: TipoCompra | undefined) => onChange(val)}
+              selectedValue={value ?? ""}
+              onValueChange={(val: string) => onChange(val || undefined)}
               prompt="Tipo de compra"
             >
-              <Picker.Item label="Selecione..." value={undefined} />
+              <Picker.Item label="Selecione..." value="" />
               {tipos.map((t) => (
                 <Picker.Item key={t} label={t} value={t} />
               ))}


### PR DESCRIPTION
## Summary
- prevent Picker from sending undefined

## Testing
- `npm test` (fails: Missing script)
- `npm run web` (fails: fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_68b7110c1de4832fa2f2c1476efdb4d6