### PR TITLE
Fix Expo offline startup and satisfy TypeScript

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -14,6 +14,7 @@ export default function App() {
       <StatusBar barStyle="light-content" />
       <NavigationContainer>
         <Tab.Navigator
+          id={undefined}
           screenOptions={{
             headerStyle: { backgroundColor: "#0B1220" },
             headerTintColor: "#F8FAFC",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "start": "expo start",
+    "start:offline": "expo start --offline",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web"


### PR DESCRIPTION
## Summary
- add explicit `id` to `Tab.Navigator` to satisfy React Navigation types
- add npm script for offline Expo startup to run without network

## Testing
- `npx tsc --noEmit`
- `npm run start:offline`

------
https://chatgpt.com/codex/tasks/task_e_68b717370458832fbe5d5fd6089bb549