### PR TITLE
fix: update Babel plugins for reanimated

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -3,7 +3,7 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ["babel-preset-expo"],
-    plugins: ["nativewind/babel"],
+    plugins: ["react-native-worklets/plugin", "nativewind/babel"],
   };
 };
 

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,4 +1,5 @@
 import "react-native-gesture-handler";
 import { registerRootComponent } from "expo";
 import App from "./App";
+
 registerRootComponent(App);


### PR DESCRIPTION
## Summary
- use react-native-worklets/plugin in Babel config so bundling works with Reanimated
- add newline to entry point

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68b72da52184832f9488b2dab57e66d2